### PR TITLE
feat: add unraid service widget

### DIFF
--- a/docs/widgets/services/index.md
+++ b/docs/widgets/services/index.md
@@ -139,6 +139,7 @@ You can also find a list of all available service widgets in the sidebar navigat
 - [TubeArchivist](tubearchivist.md)
 - [UniFi Controller](unifi-controller.md)
 - [Unmanic](unmanic.md)
+- [Unraid](unraid.md)
 - [Uptime Kuma](uptime-kuma.md)
 - [UptimeRobot](uptimerobot.md)
 - [UrBackup](urbackup.md)

--- a/docs/widgets/services/unraid.md
+++ b/docs/widgets/services/unraid.md
@@ -1,0 +1,17 @@
+---
+title: Unraid
+description: Unraid Widget Configuration
+---
+
+Learn more about [Unraid](https://unraid.net/).
+
+This widget displays CPU load, memory usage and overall disk utilisation by querying the Unraid API.
+
+Allowed fields: ["cpu", "memory", "disk"].
+
+```yaml
+widget:
+  type: unraid
+  url: http://unraid.host.or.ip
+  key: your_api_key
+```

--- a/homepage.yml
+++ b/homepage.yml
@@ -1,0 +1,8 @@
+- Services:
+    - Unraid:
+        icon: unraid.png
+        href: http://unraid.host.or.ip
+        widget:
+          type: unraid
+          url: http://unraid.host.or.ip
+          key: your_api_key

--- a/public/locales/af/common.json
+++ b/public/locales/af/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/bg/common.json
+++ b/public/locales/bg/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ca/common.json
+++ b/public/locales/ca/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/da/common.json
+++ b/public/locales/da/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Nächster Monat",
         "previousMonthlyCost": "Vorh. Monat",
         "nextRenewingSubscription": "Nächste Zahlung"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/eo/common.json
+++ b/public/locales/eo/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/eu/common.json
+++ b/public/locales/eu/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Mois prochain",
         "previousMonthlyCost": "Mois précédent",
         "nextRenewingSubscription": "Prochain paiement"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "חודש הבא",
         "previousMonthlyCost": "חודש קודם",
         "nextRenewingSubscription": "תשלום הבא"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/hr/common.json
+++ b/public/locales/hr/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/hu/common.json
+++ b/public/locales/hu/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/lv/common.json
+++ b/public/locales/lv/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ms/common.json
+++ b/public/locales/ms/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/nb-NO/common.json
+++ b/public/locales/nb-NO/common.json
@@ -746,5 +746,10 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/no/common.json
+++ b/public/locales/no/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -746,5 +746,10 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Próximo mês",
         "previousMonthlyCost": "Mês anterior",
         "nextRenewingSubscription": "Próximo pagamento"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/pt_BR/common.json
+++ b/public/locales/pt_BR/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ro/common.json
+++ b/public/locales/ro/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Следующий месяц",
         "previousMonthlyCost": "Прошлый месяц",
         "nextRenewingSubscription": "Следующая оплата"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/sk/common.json
+++ b/public/locales/sk/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/sl/common.json
+++ b/public/locales/sl/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/sr/common.json
+++ b/public/locales/sr/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Следећи месец",
         "previousMonthlyCost": "Претходни месец",
         "nextRenewingSubscription": "Следећа уплата"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/te/common.json
+++ b/public/locales/te/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/th/common.json
+++ b/public/locales/th/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Sonraki Ay",
         "previousMonthlyCost": "Önceki Ay",
         "nextRenewingSubscription": "Sonraki Ödeme"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/yue/common.json
+++ b/public/locales/yue/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/zh-CN/common.json
+++ b/public/locales/zh-CN/common.json
@@ -746,5 +746,10 @@
         "physicalRelease": "Physical release",
         "inCinemas": "In cinemas",
         "digitalRelease": "Digital release"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/zh-Hans/common.json
+++ b/public/locales/zh-Hans/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -1083,5 +1083,10 @@
         "nextMonthlyCost": "Next Month",
         "previousMonthlyCost": "Prev. Month",
         "nextRenewingSubscription": "Next Payment"
+    },
+    "unraid": {
+        "cpu": "CPU",
+        "memory": "Memory",
+        "disk": "Disk"
     }
 }

--- a/src/widgets/unraid/component.jsx
+++ b/src/widgets/unraid/component.jsx
@@ -1,0 +1,45 @@
+import Block from "components/services/widget/block";
+import Container from "components/services/widget/container";
+import { useTranslation } from "next-i18next";
+
+import useWidgetAPI from "utils/proxy/use-widget-api";
+
+export default function Component({ service }) {
+  const { t } = useTranslation();
+  const { widget } = service;
+
+  const { data: stats, error } = useWidgetAPI(widget);
+
+  if (error) {
+    return <Container service={service} error={error} />;
+  }
+
+  if (!stats) {
+    return (
+      <Container service={service}>
+        <Block label="unraid.cpu" />
+        <Block label="unraid.memory" />
+        <Block label="unraid.disk" />
+      </Container>
+    );
+  }
+
+  const cpuLoad = stats.cpu?.load_percent;
+  const memoryUsage =
+    stats.memory?.used_percent ??
+    ((stats.memory?.used / stats.memory?.total) * 100);
+
+  const arrayTotal = stats.array_total || { total: 0, used: 0 };
+  const cacheTotal = stats.cache_total || { total: 0, used: 0 };
+  const totalDisk = (arrayTotal.total || 0) + (cacheTotal.total || 0);
+  const usedDisk = (arrayTotal.used || 0) + (cacheTotal.used || 0);
+  const diskUsage = totalDisk ? (usedDisk / totalDisk) * 100 : 0;
+
+  return (
+    <Container service={service}>
+      <Block label="unraid.cpu" value={t("common.percent", { value: cpuLoad })} />
+      <Block label="unraid.memory" value={t("common.percent", { value: memoryUsage })} />
+      <Block label="unraid.disk" value={t("common.percent", { value: diskUsage })} />
+    </Container>
+  );
+}

--- a/src/widgets/unraid/widget.js
+++ b/src/widgets/unraid/widget.js
@@ -1,0 +1,8 @@
+import genericProxyHandler from "utils/proxy/handlers/generic";
+
+const widget = {
+  api: "{url}/unraid/api?apikey={key}",
+  proxyHandler: genericProxyHandler,
+};
+
+export default widget;

--- a/src/widgets/widgets.js
+++ b/src/widgets/widgets.js
@@ -130,6 +130,7 @@ import truenas from "./truenas/widget";
 import tubearchivist from "./tubearchivist/widget";
 import unifi from "./unifi/widget";
 import unmanic from "./unmanic/widget";
+import unraid from "./unraid/widget";
 import uptimekuma from "./uptimekuma/widget";
 import uptimerobot from "./uptimerobot/widget";
 import urbackup from "./urbackup/widget";
@@ -278,6 +279,7 @@ const widgets = {
   unifi,
   unifi_console: unifi,
   unmanic,
+  unraid,
   uptimekuma,
   uptimerobot,
   urbackup,


### PR DESCRIPTION
## Summary
- add Unraid widget to display CPU, memory and disk usage
- document and translate Unraid widget
- provide sample configuration and register new widget

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b7ef47d083288302426aada162ab